### PR TITLE
Premake Fixes

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -22,7 +22,8 @@ project "Minecraft Clone"
 	{
 		"Source/Core/Dependencies/GLEW/include",
 		"Source/Core/Dependencies/GLFW/include",
-		"Source/Core/Dependencies/glm"
+		"Source/Core/Dependencies/glm",
+		"Source/Core/Dependencies/imgui"
 	}
 
 	links

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,37 +1,36 @@
 workspace "Minecraft Clone"
 	architecture "x86"
-   configurations 
-   { 
-      "Debug", 
-      "Release" 
-   }
+	configurations 
+	{ 
+		"Debug", 
+		"Release" 
+	}
 
 project "Minecraft Clone"
-   location "Source"
-   kind "ConsoleApp"
-   language "C++"
-   targetdir "Source/bin/%{cfg.buildcfg}"
+	location "Source"
+	kind "ConsoleApp"
+	language "C++"
+	targetdir "Source/bin/%{cfg.buildcfg}"
 
-   files 
-   { 
-      "Source/**.h", 
-      "Source/**.cpp" 
-   }
+	files 
+	{ 
+		"Source/**.h", 
+		"Source/**.cpp" 
+	}
    
-   includedirs
-   {
-      "Source/Core/Dependencies/GLEW/include",
-      "Source/Core/Dependencies/GLFW/include",
-      "Source/Core/Dependencies/glm"
-   }
+	includedirs
+	{
+		"Source/Core/Dependencies/GLEW/include",
+		"Source/Core/Dependencies/GLFW/include",
+		"Source/Core/Dependencies/glm"
+	}
 
-   links
-   {
-      "glew32s.lib",
-      "glfw3.lib",
-      "opengl32.lib",
-      "opengl32.lib",
-	   "kernel32.lib",
+	links
+	{
+		"glew32s.lib",
+		"glfw3.lib",
+		"opengl32.lib",
+		"kernel32.lib",
 		"user32.lib",
 		"gdi32.lib",
 		"winspool.lib",
@@ -43,36 +42,36 @@ project "Minecraft Clone"
 		"uuid.lib",
 		"odbc32.lib",
 		"odbccp32.lib"
-   }
+	}
    
-   libdirs
-   {
-      "Source/Core/Dependencies/GLEW/lib",
-      "Source/Core/Dependencies/GLFW/lib"
-   }
+	libdirs
+	{
+		"Source/Core/Dependencies/GLEW/lib",
+		"Source/Core/Dependencies/GLFW/lib"
+	}
   
-   filter "system:windows"
-      cppdialect "C++17"
-      staticruntime "On"
-      systemversion "latest"
+	filter "system:windows"
+		cppdialect "C++17"
+		staticruntime "On"
+		systemversion "latest"
 
-      defines
-      {
-         "MC_CLONE_WINDOWS"
-      }
+		defines
+		{
+			"MC_CLONE_WINDOWS"
+		}
 
-   filter "configurations:Debug"
-      defines 
-      { 
-         "DEBUG",
-         "_CRT_SECURE_NO_WARNINGS"
-      }
-      symbols "On"
+	filter "configurations:Debug"
+		defines 
+		{ 
+			"DEBUG",
+			"_CRT_SECURE_NO_WARNINGS"
+		}
+		symbols "On"
 
-   filter "configurations:Release"
-      defines 
-      { 
-         "NDEBUG",
-         "_CRT_SECURE_NO_WARNINGS"
-      }
-      optimize "On"
+	filter "configurations:Release"
+		defines 
+		{ 
+			"NDEBUG",
+			"_CRT_SECURE_NO_WARNINGS"
+		}
+		optimize "On"


### PR DESCRIPTION
- Removed opengl32.lib link duplicate
- Added ImGui include directory
- Arranged premake5.lua spaces
> Suggestion to delete redundant files at <strong>Core/Dependencies/imgui/main.cpp</strong> and <strong>Core/Dependencies/glm/glm/detail/dummy.cpp</strong> which causes 'main is already defined error' after including imgui and glm in premake