### PR TITLE
Fix overlapping for loop variables

### DIFF
--- a/Source/Core/World/World.cpp
+++ b/Source/Core/World/World.cpp
@@ -516,13 +516,13 @@ namespace Minecraft
 				{
 					glm::vec3 normal;
 
-					for (int i = 0; i < 3; ++i)
+					for (int j = 0; j < 3; ++j)
 					{
-						normal[i] = (t == tvec[i]);
+						normal[j] = (t == tvec[j]);
 
-						if (sign[i])
+						if (sign[j])
 						{
-							normal[i] = -normal[i];
+							normal[j] = -normal[j];
 						}
 					}
 


### PR DESCRIPTION
In World.cpp there was an inner for loop that declared its index variable as `int i`, but the outer loop already had an int with the same name. This is a small oversight that could be problematic, so I renamed the inner for loop's index to `j` to avoid conflict.